### PR TITLE
Resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can train your **YOLO-NAS** model with **Single Command Line**
   `-w`, `--weight`: path to pre-trained model weight (default: `coco` weight) <br>
   `--gpus`: Train on multiple gpus <br>
   `--cpu`: Train on CPU <br>
+  `--resume`: To resume model training <br>
   
   **Other Training Parameters:**<br>
   `--warmup_mode`: Warmup Mode, eg: Linear Epoch Step <br>

--- a/train.py
+++ b/train.py
@@ -29,6 +29,8 @@ if __name__ == '__main__':
                 help="Model type (eg: yolo_nas_s)")
     ap.add_argument("-w", "--weight", type=str, default='coco',
                     help="path to pre-trained model weight")
+    ap.add_argument("-r", "--resume", action='store_true',
+                    help="to resume model training")
     ap.add_argument("-s", "--size", type=int, default=640,
                     help="input image size")
     ap.add_argument("--gpus", action='store_true',
@@ -128,11 +130,19 @@ if __name__ == '__main__':
             }
         )
 
-    model = models.get(
-        args['model'],
-        num_classes=len(yaml_params['names']), 
-        pretrained_weights=args["weight"]
-    )
+    # To Resume Training
+    if args['resume']:
+        model = models.get(
+            args['model'],
+            num_classes=len(yaml_params['names']),
+            checkpoint_path=args["weight"]
+        )
+    else:
+        model = models.get(
+            args['model'],
+            num_classes=len(yaml_params['names']), 
+            pretrained_weights=args["weight"]
+        )
 
     train_params = {
         # ENABLING SILENT MODE


### PR DESCRIPTION
To solve #44 issue.
added resume option for to continue training from last ckpt.

## 🤖 Train
You can train your **YOLO-NAS** model with **Single Command Line**

<details>
  <summary>Args</summary>
  
  `-i`, `--data`: path to data.yaml
  `-n`, `--name`: Checkpoint dir name
  `-b`, `--batch`: Training batch size
  `-e`, `--epoch`: number of training epochs.
  `-s`, `--size`: Input image size
  `-j`, `--worker`: Training number of workers
  `-m`, `--model`: Model type (Choices: `yolo_nas_s`, `yolo_nas_m`, `yolo_nas_l`)
  `-w`, `--weight`: path to pre-trained model weight (default: `coco` weight)
  `--gpus`: Train on multiple gpus
  `--cpu`: Train on CPU
  `--resume`: To resume model training
  
  **Other Training Parameters:**
  `--warmup_mode`: Warmup Mode, eg: Linear Epoch Step 
  `--warmup_initial_lr`: Warmup Initial LR
  `--lr_warmup_epochs`: LR Warmup Epochs
  `--initial_lr`: Inital LR
  `--lr_mode`: LR Mode, eg: cosine
  `--cosine_final_lr_ratio`: Cosine Final LR Ratio
  `--optimizer`: Optimizer, eg: Adam
  `--weight_decay`: Weight Decay
  
</details>

**Example:**
```
python3 train.py --data /dir/dataset/data.yaml --batch 6 --epoch 100 --model yolo_nas_m --size 640
```