### PR TITLE
Downgrade torch version and bump super-gradients

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ conda activate yolo-nas
 pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cu113 
 # For Quantization Aware Training
 pip install pytorch-quantization==2.1.2 --extra-index-url https://pypi.ngc.nvidia.com
-pip install super-gradients==3.1.3
+pip install super-gradients==3.2.0
 ```
 #### OR
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd YOLO-NAS
 ```
 conda create -n yolo-nas python=3.9 -y
 conda activate yolo-nas
-conda install pytorch==1.12.1 torchvision==0.13.1 torchaudio==0.12.1 cudatoolkit=11.3 -c pytorch -y
+pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cu113 
 # For Quantization Aware Training
 pip install pytorch-quantization==2.1.2 --extra-index-url https://pypi.ngc.nvidia.com
 pip install super-gradients==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-super-gradients==3.1.3
+super-gradients==3.2.0
 # urllib3==1.25.9


### PR DESCRIPTION
fixes - #56 
The setup has been tested with super-gradients 3.1.3 torch-quantization  2.1.2 and torch 1.11. I have bumped super-gradients to 3.2.0 based on the comments in https://github.com/Deci-AI/super-gradients/issues/1045#issuecomment-1679077997